### PR TITLE
Fix Scaffold.of(context) calls and update Scaffold constructors

### DIFF
--- a/lib/contextual_scaffold.dart
+++ b/lib/contextual_scaffold.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
 import 'controller/items_controller.dart';
@@ -76,10 +77,7 @@ class ContextualScaffold<T> extends StatelessWidget {
         bool isActionModeEnable() =>
             Provider.of<ItemsController<T>>(context).actionModeEnable;
         return Scaffold(
-          appBar: PreferredSize(
-              preferredSize: const Size(double.infinity, kToolbarHeight),
-              child: isActionModeEnable() ? contextualAppBar : appBar,
-          ),
+          appBar: isActionModeEnable() ? contextualAppBar : appBar,
           body: child,
           floatingActionButton: floatingActionButton,
           floatingActionButtonLocation: floatingActionButtonLocation,

--- a/lib/contextual_scaffold.dart
+++ b/lib/contextual_scaffold.dart
@@ -11,6 +11,8 @@ class ContextualScaffold<T> extends StatelessWidget {
 
   final bool extendBodyBehindAppBar;
 
+  final bool externalProvider;
+
   final PreferredSizeWidget appBar;
   final ContextualAppBar<T> contextualAppBar;
 
@@ -46,6 +48,7 @@ class ContextualScaffold<T> extends StatelessWidget {
     Key key,
     this.appBar,
     @required this.contextualAppBar,
+    this.externalProvider = false,
     this.body,
     this.floatingActionButton,
     this.floatingActionButtonLocation,
@@ -71,11 +74,22 @@ class ContextualScaffold<T> extends StatelessWidget {
         super(key: key);
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<ItemsController<T>>(
-      create: (BuildContext context) => ItemsController<T>(),
-      builder: (BuildContext context, Widget child) {
-        bool isActionModeEnable() =>
-            Provider.of<ItemsController<T>>(context).actionModeEnable;
+    if (externalProvider) {
+      return buildScaffold(context);
+    } else {
+      return ChangeNotifierProvider<ItemsController<T>>(
+          create: (BuildContext context) => ItemsController<T>(),
+          builder: (BuildContext context, Widget child) {
+            return buildScaffold(context);
+          }
+      );
+    }
+  }
+
+  Widget buildScaffold(BuildContext context) {
+    return Consumer<ItemsController<T>>(
+      builder: (context, itemsController, child) {
+        bool isActionModeEnable() => itemsController.actionModeEnable;
         return Scaffold(
           appBar: isActionModeEnable() ? contextualAppBar : appBar,
           body: child,

--- a/lib/contextual_scaffold.dart
+++ b/lib/contextual_scaffold.dart
@@ -13,6 +13,8 @@ class ContextualScaffold<T> extends StatelessWidget {
 
   final bool externalProvider;
 
+  final bool allowZeroItems;
+
   final PreferredSizeWidget appBar;
   final ContextualAppBar<T> contextualAppBar;
 
@@ -49,6 +51,7 @@ class ContextualScaffold<T> extends StatelessWidget {
     this.appBar,
     @required this.contextualAppBar,
     this.externalProvider = false,
+    this.allowZeroItems = false,
     this.body,
     this.floatingActionButton,
     this.floatingActionButtonLocation,
@@ -78,7 +81,7 @@ class ContextualScaffold<T> extends StatelessWidget {
       return buildScaffold(context);
     } else {
       return ChangeNotifierProvider<ItemsController<T>>(
-          create: (BuildContext context) => ItemsController<T>(),
+          create: (BuildContext context) => ItemsController<T>(allowZeroItems: allowZeroItems),
           builder: (BuildContext context, Widget child) {
             return buildScaffold(context);
           }

--- a/lib/contextual_scaffold.dart
+++ b/lib/contextual_scaffold.dart
@@ -75,38 +75,28 @@ class ContextualScaffold<T> extends StatelessWidget {
       builder: (BuildContext context, Widget child) {
         bool isActionModeEnable() =>
             Provider.of<ItemsController<T>>(context).actionModeEnable;
-        return Stack(
-          children: [
-            Positioned.fill(
-              child: Scaffold(
-                appBar: appBar,
-                body: child,
-                floatingActionButton: floatingActionButton,
-                floatingActionButtonLocation: floatingActionButtonLocation,
-                floatingActionButtonAnimator: floatingActionButtonAnimator,
-                persistentFooterButtons: persistentFooterButtons,
-                drawer: drawer,
-                endDrawer: endDrawer,
-                bottomNavigationBar: bottomNavigationBar,
-                bottomSheet: bottomSheet,
-                backgroundColor: backgroundColor,
-                resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-                primary: primary,
-                drawerDragStartBehavior: drawerDragStartBehavior,
-                extendBody: extendBody,
-                extendBodyBehindAppBar: extendBody,
-                drawerScrimColor: drawerScrimColor,
-                drawerEdgeDragWidth: drawerEdgeDragWidth,
-              ),
-            ),
-            if (isActionModeEnable())
-              Positioned(
-                top: 0,
-                right: 0,
-                left: 0,
-                child: contextualAppBar,
-              ),
-          ],
+        return Scaffold(
+          appBar: PreferredSize(
+              preferredSize: const Size(double.infinity, kToolbarHeight),
+              child: isActionModeEnable() ? contextualAppBar : appBar,
+          ),
+          body: child,
+          floatingActionButton: floatingActionButton,
+          floatingActionButtonLocation: floatingActionButtonLocation,
+          floatingActionButtonAnimator: floatingActionButtonAnimator,
+          persistentFooterButtons: persistentFooterButtons,
+          drawer: drawer,
+          endDrawer: endDrawer,
+          bottomNavigationBar: bottomNavigationBar,
+          bottomSheet: bottomSheet,
+          backgroundColor: backgroundColor,
+          resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+          primary: primary,
+          drawerDragStartBehavior: drawerDragStartBehavior,
+          extendBody: extendBody,
+          extendBodyBehindAppBar: extendBody,
+          drawerScrimColor: drawerScrimColor,
+          drawerEdgeDragWidth: drawerEdgeDragWidth,
         );
       },
       child: body,

--- a/lib/controller/items_controller.dart
+++ b/lib/controller/items_controller.dart
@@ -10,6 +10,10 @@ class ItemsController<T> extends ChangeNotifier {
 
   List<T> get items => _items.toList();
 
+  final bool allowZeroItems;
+  
+  ItemsController({this.allowZeroItems = false});
+
   bool isItemPresent(T item) => _items.contains(item);
   StreamController<bool> _isActionModeEnableController =
       StreamController.broadcast();
@@ -34,6 +38,17 @@ class ItemsController<T> extends ChangeNotifier {
     _modifyActionMode(true);
   }
 
+  void enableActionModeList(Iterable<T> items) {
+    _items.addAll(items);
+    _modifyActionMode(true);
+  }
+
+  void enableActionModeZeroItems() {
+    if (allowZeroItems) {
+      _modifyActionMode(true);
+    }
+  }
+
   void disableActionMode() {
     _modifyActionMode(false);
     emptySelection();
@@ -56,7 +71,7 @@ class ItemsController<T> extends ChangeNotifier {
     if (!_actionModeEnabled) {
       _modifyActionMode(true);
     }
-    if (_items.isEmpty) {
+    if (_items.isEmpty && !allowZeroItems) {
       disableActionMode();
     }
     notifyListeners();

--- a/lib/sliver/contextual_scrollview.dart
+++ b/lib/sliver/contextual_scrollview.dart
@@ -1200,6 +1200,11 @@ class _NestedScrollPosition extends ScrollPosition
     _parent?.detach(this);
     super.dispose();
   }
+
+  @override
+  void pointerScroll(double delta) {
+    // TODO: implement pointerScroll
+  }
 }
 
 enum _NestedBallisticScrollActivityMode { outer, inner, independent }

--- a/lib/sliver/contextual_scrollview.dart
+++ b/lib/sliver/contextual_scrollview.dart
@@ -22,6 +22,7 @@ class ContextualScrollView<T> extends StatefulWidget {
     this.scrollDirection = Axis.vertical,
     this.reverse = false,
     this.physics,
+    this.allowZeroItems = false,
     @required this.headerSliverBuilder,
     @required this.body,
     @required this.contextualAppBar,
@@ -59,6 +60,8 @@ class ContextualScrollView<T> extends StatefulWidget {
   ///
   /// Defaults to false.
   final bool reverse;
+
+  final bool allowZeroItems;
 
   /// How the scroll view should respond to user input.
   ///
@@ -277,7 +280,7 @@ class ContextualScrollViewState<T> extends State<ContextualScrollView> {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<ItemsController<T>>(
-      create: (BuildContext context) => ItemsController<T>(),
+      create: (BuildContext context) => ItemsController<T>(allowZeroItems: widget.allowZeroItems),
       child: Builder(builder: (context) {
         bool isActionModeEnable() =>
             Provider.of<ItemsController<T>>(context).actionModeEnable;

--- a/lib/widgets/contextual_action_bar.dart
+++ b/lib/widgets/contextual_action_bar.dart
@@ -207,7 +207,7 @@ class _ContextualAppBarState<T> extends State<ContextualAppBar> {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = Theme.of(context);
     final AppBarTheme appBarTheme = AppBarTheme.of(context);
-    final ScaffoldState scaffold = Scaffold.of(context, nullOk: true);
+    final ScaffoldState scaffold = Scaffold.of(context);
 
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
 

--- a/lib/widgets/contextual_action_bar.dart
+++ b/lib/widgets/contextual_action_bar.dart
@@ -1,9 +1,11 @@
 import 'package:contextualactionbar/actions/action_mode.dart';
+import 'package:contextualactionbar/widgets/contextual_close_action.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../contextualactionbar.dart';
 import 'contextual_action.dart';
 import '../controller/items_controller.dart';
 import '../typedef/counter_builder.dart';
@@ -14,6 +16,7 @@ class ContextualAppBar<T> extends StatefulWidget
     Key key,
     @required this.counterBuilder,
     @required this.contextualActions,
+    this.leading,
     this.flexibleSpace,
     this.bottom,
     this.elevation,
@@ -50,6 +53,9 @@ class ContextualAppBar<T> extends StatefulWidget
   /// For less common operations, consider using a [PopupMenuButton] as the
   /// last action.
   final List<ContextualAction<T>> contextualActions;
+
+  /// Action to take on cancel
+  final ContextualCloseAction<T> leading;
 
   /// This widget is stacked behind the toolbar and the tab bar. It's height will
   /// be the same as the app bar's overall height.
@@ -264,9 +270,12 @@ class _ContextualAppBarState<T> extends State<ContextualAppBar> {
     }
 
     final Widget toolbar = NavigationToolbar(
-      leading: IconButton(
-          icon: Icon(widget.closeIcon ?? Icons.close),
-          onPressed: () => ActionMode.disable<T>(context)),
+      leading: widget.leading ??
+          IconButton(
+            icon: Icon(widget.closeIcon ?? Icons.close),
+            onPressed: () {
+              ActionMode.disable<T>(context);
+      }),
       middle: Consumer<ItemsController<T>>(
         builder:
             (BuildContext context, ItemsController<T> value, Widget child) {

--- a/lib/widgets/contextual_close_action.dart
+++ b/lib/widgets/contextual_close_action.dart
@@ -1,0 +1,33 @@
+import 'package:contextualactionbar/actions/action_mode.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../controller/items_controller.dart';
+import '../typedef/handle_items.dart';
+
+class ContextualCloseAction<T> extends StatelessWidget {
+  final HandleItems<T> itemsHandler;
+  final IconData closeIcon;
+  const ContextualCloseAction(
+      {Key key, this.itemsHandler, this.closeIcon})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ItemsController<T>>(
+      builder: (BuildContext context, ItemsController<T> value, Widget child) {
+        return IconButton(
+            icon: Icon(closeIcon ?? Icons.close),
+            onPressed: () {
+              if (itemsHandler != null) {
+                itemsHandler(value.items);
+              }
+              ActionMode.disable<T>(context);
+            });
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Container(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
The new version of `Scaffold` in flutter does not have a `nullOk` parameter, so I removed that.

I also ran into an issue where `ContextualActionBar` was calling `Scaffold.of(context)` but since it was a sibling in the `Stack`, it could not find the correct `Scaffold`. I updated this so it is within the `Scaffold`, and the `Scaffold` builds either the `appBar` or `contextualAppBar` depending on if `ActionMode` is enabled or not.